### PR TITLE
行数テストを定期実行から外す

### DIFF
--- a/definitions/gbizinfo_staging/basic_assert.sqlx
+++ b/definitions/gbizinfo_staging/basic_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/certification_assert.sqlx
+++ b/definitions/gbizinfo_staging/certification_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/commendation_assert.sqlx
+++ b/definitions/gbizinfo_staging/commendation_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/finance_assert.sqlx
+++ b/definitions/gbizinfo_staging/finance_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/patent_assert.sqlx
+++ b/definitions/gbizinfo_staging/patent_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/procurement_assert.sqlx
+++ b/definitions/gbizinfo_staging/procurement_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/subsidy_assert.sqlx
+++ b/definitions/gbizinfo_staging/subsidy_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/gbizinfo_staging/workplace_assert.sqlx
+++ b/definitions/gbizinfo_staging/workplace_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "gbizinfo_staging",
-  tags: ["daily"]
+  schema: "gbizinfo_staging"
 }
 
 SELECT

--- a/definitions/houjinbangou_staging/latest_assert.sqlx
+++ b/definitions/houjinbangou_staging/latest_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "houjinbangou_staging",
-  tags: ["monthly"]
+  schema: "houjinbangou_staging"
 }
 
 SELECT

--- a/definitions/shukujitsu_staging/holidays_assert.sqlx
+++ b/definitions/shukujitsu_staging/holidays_assert.sqlx
@@ -1,7 +1,6 @@
 config {
   type: "assertion",
-  schema: "shukujitsu_staging",
-  tags: ["daily"]
+  schema: "shukujitsu_staging"
 }
 
 SELECT


### PR DESCRIPTION
行数テストは、元データが変化しないタイミングでやっても無駄なので除去