### PR TITLE
gbizinfo.certificationの行数減少

### DIFF
--- a/definitions/gbizinfo_staging/certification_assert.sqlx
+++ b/definitions/gbizinfo_staging/certification_assert.sqlx
@@ -8,4 +8,4 @@ SELECT
 FROM
   ${ref("gbizinfo_staging", "certification")}
 HAVING
-  num_rows < 143803 -- 2022-12-30時点の行数
+  num_rows < 122995 -- 2023-04-03時点の行数


### PR DESCRIPTION
2023-04-01のデータ更新で、gBizINFOのcertificationテーブルの行数が、143803から122995に減少していた。